### PR TITLE
Use new mod filename and parse JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Use chmod +x ./ersc-update.sh from the folder you have downloaded the script to.
 Then type ./ersc-update.sh
 Before running the script, ensure you have the following tools installed on your system:
 
-*   `curl`
-*   `wget`
-*   `unzip`
+* `curl`
+* `wget`
+* `unzip`
+* `jq`
 
 These are typically pre-installed on most Linux distributions.
 
@@ -97,13 +98,14 @@ Here are some common issues you might encounter and how to resolve them:
 *   **Issue:** When you try to run the script, you get an error like "Permission denied."
 *   **Solution:** You likely forgot to make the script executable. Follow the steps in the "Make the Script Executable" section above using `chmod +x`.
 
-### 2. "command not found" errors (e.g., `curl`, `wget`, `unzip`)
+### 2. "command not found" errors (e.g., `curl`, `wget`, `unzip`, `jq`)
 
-*   **Issue:** The script exits with an error indicating a command like `curl`, `wget`, or `unzip` is not found.
+*   **Issue:** The script exits with an error indicating a command like 
+    `curl`, `wget`, `unzip`, or `jq` is not found.
 *   **Solution:** These are external tools the script relies on. Ensure they are installed on your system.
-    *   **Debian/Ubuntu:** `sudo apt install curl wget unzip`
-    *   **Fedora:** `sudo dnf install curl wget unzip`
-    *   **Arch Linux:** `sudo pacman -S curl wget unzip`
+    *   **Debian/Ubuntu:** `sudo apt install curl wget unzip jq`
+    *   **Fedora:** `sudo dnf install curl wget unzip jq`
+    *   **Arch Linux:** `sudo pacman -S curl wget unzip jq`
     *   (Adjust for your specific distribution's package manager if different.)
 
 ### 3. "Could not find Elden Ring 'Game' directory"

--- a/ersc-update.sh
+++ b/ersc-update.sh
@@ -68,17 +68,26 @@ find_game_directory() {
     fi
 }
 
-# Downloads the latest 'ersc.zip' release from the GitHub repository.
+# Downloads the latest release from the GitHub repository.
 download_latest_release() {
     log_info "Finding latest Seamless Co-op release from GitHub..."
 
-    # Use a pipeline to find the download URL for the 'ersc.zip' asset.
-    # This is more robust than the original method.
     local download_url
-    download_url=$(curl --silent --fail "$REPO_API_URL" | grep "browser_download_url" | grep "ersc.zip" | cut -d '"' -f 4)
-
-    if [[ -z "$download_url" ]]; then
-        die "Could not find a download URL for 'ersc.zip'. The GitHub API response may have changed."
+    if ! download_url=$(
+        # Retrieve information on the latest mod release from the GitHub API
+        curl --silent --fail "$REPO_API_URL" |
+        # Parse the JSON API response and find the download URL
+        jq --raw-output --exit-status '
+            [
+	        .assets[] |
+	        select(
+	            .name |
+	            test("^Seamless\\.Co-op\\..*\\.zip$")
+	        )
+	    ] | first |
+	    .browser_download_url'
+    ) ; then
+        die "Could not find a download URL for 'Seamless.Co-op.*.zip'. The GitHub API response may have changed."
     fi
 
     log_info "Downloading from: $download_url"


### PR DESCRIPTION
The upstream mod author is no longer uploading the mod with the filename `ersc.zip` &mdash; now it's `Seamless.Co-op.<version>.zip`.

This patch updates the expected filename, using a regular expression to match the file regardless of version. It also fixes a bug in the previous version that caused the script to exit without printing the intended "Could not find a download URL" message.

Note that this patch also pulls in `jq` as a new dependency. While adding another dependency isn't ideal, I believe that properly parsing the JSON response from GitHub is worth it. The script is no longer sensitive to e.g. whitespace changes in the response.